### PR TITLE
Add basic audio engine

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,8 +3,22 @@ import RootGrid from './components/layout/RootGrid';
 import SubtractiveSynth from './pages/synth/SubtractiveSynth';
 import CentralWorkspace from './pages/synth/CentralWorkspace';
 import AdditiveSynth from './pages/synth/AdditiveSynth';
+import { useRef, useEffect } from 'react';
+import SynthEngine from './audio/SynthEngine';
+import AudioContextManager from './audio/AudioContextManager';
+import useKeyboardSynth from './audio/useKeyboardSynth';
 
 export default function App() {
+  const engineRef = useRef<SynthEngine>();
+
+  useEffect(() => {
+    engineRef.current = new SynthEngine();
+    AudioContextManager.getInstance().resume();
+  }, []);
+
+
+  useKeyboardSynth(engineRef.current);
+
   return (
     <RootGrid>
       {/* Left Sidebar (Subtractive Synth) */}

--- a/frontend/src/audio/AudioContextManager.ts
+++ b/frontend/src/audio/AudioContextManager.ts
@@ -1,0 +1,28 @@
+class AudioContextManager {
+  private static instance: AudioContextManager;
+
+  readonly context: AudioContext;
+  readonly masterGain: GainNode;
+
+  private constructor() {
+    this.context = new AudioContext();
+    this.masterGain = this.context.createGain();
+    this.masterGain.gain.value = 0.8;
+    this.masterGain.connect(this.context.destination);
+  }
+
+  static getInstance(): AudioContextManager {
+    if (!this.instance) {
+      this.instance = new AudioContextManager();
+    }
+    return this.instance;
+  }
+
+  async resume() {
+    if (this.context.state === 'suspended') {
+      await this.context.resume();
+    }
+  }
+}
+
+export default AudioContextManager;

--- a/frontend/src/audio/SynthEngine.ts
+++ b/frontend/src/audio/SynthEngine.ts
@@ -1,0 +1,44 @@
+import AudioContextManager from './AudioContextManager';
+import Voice from './Voice';
+import { EnvelopeOptions, OscillatorNodeOptions } from './interfaces';
+
+export default class SynthEngine {
+  private voices: Voice[] = [];
+  private activeVoices: Map<number, Voice> = new Map();
+
+  constructor(private maxVoices = 16) {}
+
+  noteOn(note: number, velocity = 1) {
+    const frequency = 440 * Math.pow(2, (note - 69) / 12);
+    const oscOptions: OscillatorNodeOptions = {
+      id: `osc-${Date.now()}`,
+      type: 'sawtooth',
+      frequency,
+    };
+    const env: EnvelopeOptions = { attack: 10, decay: 50, sustain: velocity, release: 200 };
+
+    let voice = this.voices.pop();
+    if (!voice) {
+      voice = new Voice(oscOptions, env, note);
+    } else {
+      voice = new Voice(oscOptions, env, note);
+    }
+    this.activeVoices.set(note, voice);
+    voice.start();
+  }
+
+  noteOff(note: number) {
+    const voice = this.activeVoices.get(note);
+    if (voice) {
+      voice.stop();
+      this.activeVoices.delete(note);
+      if (this.voices.length < this.maxVoices) {
+        this.voices.push(voice);
+      }
+    }
+  }
+
+  setMasterGain(value: number) {
+    AudioContextManager.getInstance().masterGain.gain.value = value;
+  }
+}

--- a/frontend/src/audio/Voice.ts
+++ b/frontend/src/audio/Voice.ts
@@ -1,0 +1,48 @@
+import AudioContextManager from './AudioContextManager';
+import { EnvelopeOptions, OscillatorNodeOptions } from './interfaces';
+
+export default class Voice {
+  private context = AudioContextManager.getInstance().context;
+  private gain = this.context.createGain();
+  private oscillator: OscillatorNode;
+  private envelope: EnvelopeOptions;
+  private active = false;
+  note: number;
+
+  constructor(options: OscillatorNodeOptions, envelope: EnvelopeOptions, note: number) {
+    this.oscillator = this.context.createOscillator();
+    this.oscillator.type = options.type;
+    this.oscillator.frequency.value = options.frequency;
+    if (options.detune) {
+      this.oscillator.detune.value = options.detune;
+    }
+    this.envelope = envelope;
+    this.gain.gain.value = 0;
+    this.oscillator.connect(this.gain);
+    this.gain.connect(AudioContextManager.getInstance().masterGain);
+    this.note = note;
+  }
+
+  start(time?: number) {
+    const t = time ?? this.context.currentTime;
+    this.oscillator.start(t);
+    const { attack } = this.envelope;
+    this.gain.gain.cancelScheduledValues(t);
+    this.gain.gain.setValueAtTime(0, t);
+    this.gain.gain.linearRampToValueAtTime(1, t + attack / 1000);
+    this.active = true;
+  }
+
+  stop(time?: number) {
+    if (!this.active) return;
+    const t = time ?? this.context.currentTime;
+    const { decay, sustain, release } = this.envelope;
+    const sustainLevel = sustain;
+    this.gain.gain.cancelScheduledValues(t);
+    this.gain.gain.setValueAtTime(this.gain.gain.value, t);
+    this.gain.gain.linearRampToValueAtTime(sustainLevel, t + decay / 1000);
+    this.gain.gain.linearRampToValueAtTime(0, t + decay / 1000 + release / 1000);
+    this.oscillator.stop(t + decay / 1000 + release / 1000 + 0.05);
+    this.active = false;
+  }
+}

--- a/frontend/src/audio/index.ts
+++ b/frontend/src/audio/index.ts
@@ -1,0 +1,3 @@
+export { default as AudioContextManager } from './AudioContextManager';
+export { default as SynthEngine } from './SynthEngine';
+export type { EnvelopeOptions, OscillatorNodeOptions, FilterNodeOptions } from './interfaces';

--- a/frontend/src/audio/interfaces.ts
+++ b/frontend/src/audio/interfaces.ts
@@ -1,0 +1,24 @@
+export interface AudioNodeOptions {
+  id: string;
+  inputs?: string[];
+  outputs?: string[];
+}
+
+export interface OscillatorNodeOptions extends AudioNodeOptions {
+  type: OscillatorType;
+  frequency: number;
+  detune?: number;
+}
+
+export interface FilterNodeOptions extends AudioNodeOptions {
+  type: BiquadFilterType;
+  frequency: number;
+  Q: number;
+}
+
+export interface EnvelopeOptions {
+  attack: number; // milliseconds
+  decay: number;  // milliseconds
+  sustain: number; // 0-1 range
+  release: number; // milliseconds
+}

--- a/frontend/src/audio/useKeyboardSynth.ts
+++ b/frontend/src/audio/useKeyboardSynth.ts
@@ -1,0 +1,53 @@
+import { useEffect } from 'react';
+import SynthEngine from './SynthEngine';
+
+const KEY_TO_NOTE: Record<string, number> = {
+  a: 60,
+  w: 61,
+  s: 62,
+  e: 63,
+  d: 64,
+  f: 65,
+  t: 66,
+  g: 67,
+  y: 68,
+  h: 69,
+  u: 70,
+  j: 71,
+  k: 72,
+  o: 73,
+  l: 74,
+  p: 75,
+};
+
+export default function useKeyboardSynth(engine?: SynthEngine) {
+  useEffect(() => {
+    if (!engine) return;
+
+    const down = new Set<string>();
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      const note = KEY_TO_NOTE[e.key];
+      if (note !== undefined && !down.has(e.key)) {
+        down.add(e.key);
+        engine.noteOn(note, 1);
+      }
+    };
+
+    const handleKeyUp = (e: KeyboardEvent) => {
+      const note = KEY_TO_NOTE[e.key];
+      if (note !== undefined) {
+        down.delete(e.key);
+        engine.noteOff(note);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    window.addEventListener('keyup', handleKeyUp);
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+      window.removeEventListener('keyup', handleKeyUp);
+    };
+  }, [engine]);
+}


### PR DESCRIPTION
## Summary
- implement `AudioContextManager` singleton for Web Audio
- create `Voice` class to represent a playable oscillator
- add `SynthEngine` to manage voices and master gain
- add `useKeyboardSynth` hook for playing notes via keyboard
- initialize engine in `App` and expose keyboard control
- add TypeScript interfaces describing audio nodes

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685208047b34832883a437b1b48d12c8