### PR TITLE
Add test tone button

### DIFF
--- a/frontend/src/components/TestToneButton.tsx
+++ b/frontend/src/components/TestToneButton.tsx
@@ -1,0 +1,33 @@
+import { useRef, useState, useEffect } from 'react';
+import { useAudioEngine } from '../audio/useAudioEngine';
+
+export default function TestToneButton() {
+  const { createOscillator, stopOscillator, resume } = useAudioEngine();
+  const [isPlaying, setIsPlaying] = useState(false);
+  const idRef = useRef('test-tone');
+
+  useEffect(() => {
+    return () => {
+      if (isPlaying) {
+        stopOscillator(idRef.current);
+      }
+    };
+  }, [isPlaying, stopOscillator]);
+
+  function handleClick() {
+    resume();
+    if (isPlaying) {
+      stopOscillator(idRef.current);
+      setIsPlaying(false);
+    } else {
+      createOscillator({ id: idRef.current, frequency: 440, detuneCents: 0, gain: 0.2 });
+      setIsPlaying(true);
+    }
+  }
+
+  return (
+    <button onClick={handleClick} style={{ marginTop: '1rem' }}>
+      {isPlaying ? 'Stop Test Tone' : 'Play Test Tone'}
+    </button>
+  );
+}

--- a/frontend/src/pages/synth/CentralWorkspace.tsx
+++ b/frontend/src/pages/synth/CentralWorkspace.tsx
@@ -5,6 +5,7 @@ import ContainerPanel from '../../components/panels/ContainerPanel';
 import AudioVisualizer from '../../components/visualizers/AudioVisualizer';
 import Knob from '../../components/controls/Knob';
 import Slider from '../../components/controls/Slider';
+import TestToneButton from '../../components/TestToneButton';
 import styles from './CentralWorkspace.module.css';
 
 export default function CentralWorkspace() {
@@ -325,6 +326,7 @@ export default function CentralWorkspace() {
           </div>
         </div>
       </ContainerPanel>
+      <TestToneButton />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add a TestToneButton component that plays or stops a simple sine wave
- include the new button at the bottom of the CentralWorkspace page

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6854198c18a88328a8f2bf8a1aaf2070